### PR TITLE
expose providers

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,6 +171,11 @@ var Module = (function () {
   };
   constructor.prototype = {
 
+    providers: {
+      controller: DSController,
+      service: DSService
+    },
+
     /**
      * Create a new thing based solely on definition
      *


### PR DESCRIPTION
it's useful to have these if you have code that needs to differentiate between services and controllers, for :sparkles: reasons :sparkles: 
